### PR TITLE
Add README and project overview documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# EmarketMall
+
+EmarketMall 是一个基于 JSP 的简易电商示例项目，使用 **Gradle** 构建。项目主要演示 Servlet + JSP + MySQL 的基本开发流程。
+
+## 目录结构
+
+- `src/main/java`：Java 源代码，按功能划分为 `controller`、`service`、`dao`、`entity`、`utils` 等包。
+- `src/main/resources`：配置文件，例如数据库连接信息 `db.properties`。
+- `src/main/webapp`：JSP 页面及静态资源，包含登录、注册、用户管理等界面。
+- `src/test/java`：简单的 JUnit 测试示例。
+
+## 构建与运行
+
+1. 确保本地已安装 JDK 8+ 和 MySQL 数据库。
+2. 修改 `src/main/resources/db.properties` 中的数据库配置，与本地环境保持一致。
+3. 在项目根目录执行：
+
+   ```bash
+   ./gradlew build
+   ```
+
+   构建成功后可在 `build/libs` 找到生成的 `war` 包。
+4. 将生成的 `war` 部署到支持 Servlet 的应用服务器（如 Tomcat）即可访问。
+
+## 进一步阅读
+
+项目的更多说明与目录解析见 `docs/PROJECT_OVERVIEW.md`，便于新成员快速上手。
+

--- a/docs/PROJECT_OVERVIEW.md
+++ b/docs/PROJECT_OVERVIEW.md
@@ -1,0 +1,33 @@
+# 项目说明
+
+本文档对 EmarketMall 项目进行简要介绍，供新成员参考。
+
+## 功能概览
+
+- **用户管理**：登录、注册及用户信息的增删改查。
+- **异步日志**：通过 `AsyncManager` 及 `AsyncFactory` 记录登录行为。
+- **工具类**：封装了字符串、日期、Servlet 相关的常用操作。
+- **页面展示**：JSP 配合 Bootstrap-table 实现基本的前端界面。
+
+## 代码结构
+
+```
+src/main/java/org/example/emarketmall
+├── common      # 基础类和公共组件
+├── controller  # Servlet 控制层
+├── dao         # 数据访问接口及实现
+├── entity      # 实体类
+├── service     # 业务逻辑处理
+├── utils       # 工具包
+└── filter      # 过滤器等
+```
+
+数据库连接配置位于 `src/main/resources/db.properties`，请根据实际环境调整。
+
+## 学习建议
+
+1. 从 `controller` 层入手，结合 JSP 页面理解请求与响应流程。
+2. 阅读 `service` 与 `dao` 的实现，掌握数据库操作方式。
+3. 熟悉 `utils` 包中的工具类，这些在项目中被频繁使用。
+4. 构建项目时使用 `./gradlew build`，如需执行测试可运行 `./gradlew test`（环境需预先配置好）。
+


### PR DESCRIPTION
## Summary
- document project layout and build instructions in README
- add `docs/PROJECT_OVERVIEW.md` with module explanations and learning tips

## Testing
- `./gradlew test` *(fails: Could not initialize class org.codehaus.groovy.runtime.InvokerHelper)*

------
https://chatgpt.com/codex/tasks/task_e_684000c0abc8832fb7ed3e5191837eff